### PR TITLE
handle toolbar stats loading in 2.1.54-qt5

### DIFF
--- a/morph/errors/profileNotYetLoadedException.py
+++ b/morph/errors/profileNotYetLoadedException.py
@@ -1,0 +1,3 @@
+class ProfileNotYetLoadedException(Exception):
+    "Raised when the profile is not yet loaded"
+    pass

--- a/morph/preferences.py
+++ b/morph/preferences.py
@@ -2,6 +2,8 @@
 import importlib
 from aqt import mw
 
+from .errors.profileNotYetLoadedException import ProfileNotYetLoadedException
+
 # retrieving the configuration using get_config is very expensive operation
 # instead, save it 
 config_data = None
@@ -64,7 +66,8 @@ def _init_config_py():
 
 
 def _get_config_py_preference(key, modelId=None, deckId=None):
-    assert config_py, 'Tried to use cfgMods before profile loaded'
+    if config_py == None:
+        raise ProfileNotYetLoadedException("Tried to use cfgMods before profile loaded")
     profile = mw.pm.name
     model = mw.col.models.get(modelId)['name'] if modelId else None
     deck = mw.col.decks.get(deckId)['name'] if deckId else None

--- a/morph/stats.py
+++ b/morph/stats.py
@@ -10,6 +10,7 @@ from aqt.utils import tooltip
 from .util import mw
 from .preferences import get_preference as cfg
 
+from .errors.profileNotYetLoadedException import ProfileNotYetLoadedException
 
 def getStatsPath(): return cfg('path_stats')
 
@@ -22,7 +23,7 @@ def loadStats():
         return d
     except IOError:  # file DNE => create it
         return updateStats()
-    except AssertionError:  # profile not loaded yet, can't do anything but wait
+    except ProfileNotYetLoadedException:  # profile not loaded yet, can't do anything but wait
         return None
 
 


### PR DESCRIPTION
handle the case where the toolbar stats are loaded before the profile

Since anki 4.1.50 the "top_toolbar_did_init_links" hooks is trigger before the profile is loaded which raised an error because we need the profile to be loaded to be able to retrieve the stats.